### PR TITLE
Communicate inferior proc error to parent proc via pipe + Proc tests

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,9 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/include",
-                "${workspaceFolder}/**/include"
+                "${workspaceFolder}/**/include",
+                "${workspaceFolder}/build/_deps/googletest-src/googletest/include",
+                "${workspaceFolder}/build/_deps/googletest-src/googlemock/include"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/g++",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,7 +71,10 @@
         "typeinfo": "cpp",
         "variant": "cpp",
         "csignal": "cpp",
-        "list": "cpp"
+        "list": "cpp",
+        "any": "cpp",
+        "forward_list": "cpp",
+        "unordered_set": "cpp"
     },
     "C_Cpp.default.compilerPath": "/usr/bin/g++"
 }

--- a/include/libsdb/sdb_pipe.h
+++ b/include/libsdb/sdb_pipe.h
@@ -1,0 +1,54 @@
+#ifndef SBB_PROCESS_PIPE_H
+#define SDB_PROCESS_PIPE_H
+
+#include <vector>
+
+namespace sdb
+{
+
+/* @brief Abstraction over an unbounded Pipe used for IPC */
+class Pipe
+{
+public:
+  explicit Pipe(bool closeOnExec);
+  ~Pipe();
+
+  Pipe(Pipe&&) = default;
+  Pipe& operator=(const Pipe&) = default;
+
+  int getRead() const;
+  int getWrite() const;
+
+  int releaseRead();
+  int releaseWrite();
+
+  void closeRead();
+  void closeWrite();
+
+  std::vector<std::byte> read();
+  void write(std::byte* source, std::size_t numBytes);
+
+private:
+  static const unsigned d_readFdIdx = 0;
+  static const unsigned d_writeFdIdx = 1;
+  int d_fds[2];
+
+private:
+  Pipe(Pipe&) = delete;
+  Pipe& operator=(Pipe&&) = delete;
+};
+
+// INLINE AND TEMPLATE DECLARATIONS
+inline int Pipe::getRead() const
+{
+  return d_fds[Pipe::d_readFdIdx];
+}
+
+inline int Pipe::getWrite() const
+{
+  return d_fds[Pipe::d_writeFdIdx];
+}
+
+} // namespace sdb
+
+#endif // SDB_PROCESS_PIPE_H

--- a/include/libsdb/sdb_pipe.h
+++ b/include/libsdb/sdb_pipe.h
@@ -6,7 +6,12 @@
 namespace sdb
 {
 
-/* @brief Abstraction over an unbounded Pipe used for IPC */
+/**
+ * @brief Convenience wrapper around a Pipe
+ *
+ * See https://man7.org/linux/man-pages/man7/pipe.7.html
+ * for more details.
+ **/
 class Pipe
 {
 public:

--- a/include/libsdb/sdb_pipe.h
+++ b/include/libsdb/sdb_pipe.h
@@ -36,7 +36,7 @@ private:
   int d_fds[2];
 
 private:
-  Pipe(Pipe&) = delete;
+  Pipe(const Pipe&) = delete;
   Pipe& operator=(const Pipe&) = delete;
 
   Pipe(Pipe&&) = delete;

--- a/include/libsdb/sdb_pipe.h
+++ b/include/libsdb/sdb_pipe.h
@@ -18,9 +18,6 @@ public:
   explicit Pipe(bool closeOnExec);
   ~Pipe();
 
-  Pipe(Pipe&&) = default;
-  Pipe& operator=(const Pipe&) = default;
-
   int getRead() const;
   int getWrite() const;
 
@@ -40,6 +37,9 @@ private:
 
 private:
   Pipe(Pipe&) = delete;
+  Pipe& operator=(const Pipe&) = delete;
+
+  Pipe(Pipe&&) = delete;
   Pipe& operator=(Pipe&&) = delete;
 };
 

--- a/include/libsdb/sdb_process.h
+++ b/include/libsdb/sdb_process.h
@@ -16,7 +16,16 @@ using ProcessUPtr = std::unique_ptr<Process>;
  * This is thrown when there's an error attaching
  * to a process.
  */
-class ProcessAttachErrror : std::runtime_error
+class ProcessAttachError : std::runtime_error
+{
+public:
+  using std::runtime_error::runtime_error;
+};
+
+/**
+ * This is thrown when there's an launching a process.
+ */
+class ProcessLaunchError : std::runtime_error
 {
 public:
   using std::runtime_error::runtime_error;
@@ -41,6 +50,9 @@ public:
   ~Process();
   static ProcessUPtr attach(pid_t pid);
   static ProcessUPtr launch(std::filesystem::path path);
+
+  Process(Process&&) = default;
+  Process& operator=(Process&&) = default;
 
   /* Resume the debugee process */
   void resume();

--- a/include/libsdb/sdb_process.h
+++ b/include/libsdb/sdb_process.h
@@ -23,7 +23,7 @@ public:
 };
 
 /**
- * This is thrown when there's an launching a process.
+ * This is thrown when there's an error launching a process.
  */
 class ProcessLaunchError : std::runtime_error
 {
@@ -38,18 +38,19 @@ private:
    * Private constructor.
    * Please use the launch/attach functions below
    */
-  Process(pid_t pid, bool cleanup_on_exit);
+  Process(pid_t pid, bool cleanupOnExit, bool isBeingTraced);
 
 private:
   const pid_t d_pid;
 
   ProcessState d_state;
-  const bool d_cleanup_on_exit;
+  const bool d_cleanupOnExit;
+  const bool d_isBeingTraced;
 
 public:
   ~Process();
   static ProcessUPtr attach(pid_t pid);
-  static ProcessUPtr launch(std::filesystem::path path);
+  static ProcessUPtr launch(std::filesystem::path path, bool traceProc = true);
 
   Process(Process&&) = default;
   Process& operator=(Process&&) = default;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_library(libsdb sdb_command.cpp sdb_stringutil.cpp sdb_process.cpp sdb_process_state.cpp)
+add_library(
+    libsdb
+    sdb_command.cpp
+    sdb_pipe.cpp
+    sdb_process.cpp
+    sdb_process_state.cpp
+    sdb_stringutil.cpp
+)
+
 add_library(sdb::libsdb ALIAS libsdb)
 
 set_target_properties(

--- a/src/sdb_pipe.cpp
+++ b/src/sdb_pipe.cpp
@@ -17,7 +17,8 @@ static const int EMPTY_PIPE_FD = -1;
 
 Pipe::Pipe(bool closeOnExec)
 {
-  if (auto rc = pipe2(d_fds, 0 /* O_NONBLOCK */ | (closeOnExec ? O_CLOEXEC : 0));
+  if (auto rc
+      = pipe2(d_fds, 0 /* O_NONBLOCK */ | (closeOnExec ? O_CLOEXEC : 0));
       rc < 0)
   {
     std::stringstream ss;

--- a/src/sdb_pipe.cpp
+++ b/src/sdb_pipe.cpp
@@ -1,0 +1,87 @@
+#include <libsdb/sdb_pipe.h>
+
+#include <fcntl.h>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <unistd.h>
+#include <utility>
+
+namespace sdb
+{
+
+namespace
+{
+static const int EMPTY_PIPE_FD = -1;
+} // namespace
+
+Pipe::Pipe(bool closeOnExec)
+{
+  if (auto rc = pipe2(d_fds, 0 /* O_NONBLOCK */ | (closeOnExec ? O_CLOEXEC : 0));
+      rc < 0)
+  {
+    std::stringstream ss;
+    ss << "Failed to create pipe, rc=" << rc;
+    throw std::runtime_error(ss.str());
+  }
+}
+
+Pipe::~Pipe()
+{
+  closeRead();
+  closeWrite();
+}
+
+int Pipe::releaseRead()
+{
+  return std::exchange(d_fds[d_readFdIdx], EMPTY_PIPE_FD);
+}
+
+int Pipe::releaseWrite()
+{
+  return std::exchange(d_fds[d_writeFdIdx], EMPTY_PIPE_FD);
+}
+
+void Pipe::closeRead()
+{
+  if (const auto readFd = getRead(); readFd != EMPTY_PIPE_FD)
+  {
+    close(readFd);
+    releaseRead();
+  }
+}
+
+void Pipe::closeWrite()
+{
+  if (const auto writeFd = getWrite(); writeFd != EMPTY_PIPE_FD)
+  {
+    close(writeFd);
+    releaseWrite();
+  }
+}
+
+std::vector<std::byte> Pipe::read()
+{
+  constexpr int numBytesToRead = 1024;
+  std::byte buff[numBytesToRead];
+  if (auto numBytesRead
+      = ::read(getRead(), static_cast<void*>(buff), numBytesToRead);
+      numBytesRead > -1)
+  {
+    return std::vector<std::byte>(buff, buff + numBytesRead);
+  }
+
+  return std::vector<std::byte>{};
+}
+
+void Pipe::write(std::byte* source, std::size_t numBytes)
+{
+  if (auto numBytesWritten
+      = ::write(getWrite(), static_cast<const void*>(source), numBytes);
+      numBytesWritten != static_cast<ssize_t>(numBytes))
+  {
+    std::cerr << "Expected to write numBytes=" << numBytes
+              << ", but got numBytesWritten=" << numBytesWritten << std::endl;
+  }
+}
+} // namespace sdb

--- a/src/sdb_pipe.cpp
+++ b/src/sdb_pipe.cpp
@@ -17,9 +17,7 @@ static const int EMPTY_PIPE_FD = -1;
 
 Pipe::Pipe(bool closeOnExec)
 {
-  if (auto rc
-      = pipe2(d_fds, 0 /* O_NONBLOCK */ | (closeOnExec ? O_CLOEXEC : 0));
-      rc < 0)
+  if (auto rc = pipe2(d_fds, 0 | (closeOnExec ? O_CLOEXEC : 0)); rc < 0)
   {
     std::stringstream ss;
     ss << "Failed to create pipe, rc=" << rc;

--- a/src/sdb_process.cpp
+++ b/src/sdb_process.cpp
@@ -113,8 +113,15 @@ ProcessUPtr Process::launch(std::filesystem::path path)
   }
 
   errorPipe.closeWrite();
-
-  // Won't this block here?
+  // If there are no exec errors in the inferior
+  // closeOnExec wil cause the write end of the pipe
+  // to close, causing EOF to be returned by this
+  // call to read from the pipe. Especially becuase
+  // at this point, there should be no open file
+  // descriptors for the write end of the pipe.
+  // closeWrite() closes the parent proc's write fd,
+  // and closeOnExec has the effect of closing the
+  // child proc's write end of the pipe.
   auto data = errorPipe.read();
   errorPipe.closeRead();
 

--- a/src/sdb_process.cpp
+++ b/src/sdb_process.cpp
@@ -13,17 +13,14 @@
 
 namespace sdb
 {
-
 namespace
 {
-
 void notifyParentThenExit(Pipe& errorPipe, std::string_view errorMsg)
 {
   std::string err(errorMsg);
   errorPipe.write(reinterpret_cast<std::byte*>(err.data()), err.size());
   exit(-1);
 }
-
 } // namespace
 
 Process::Process(pid_t pid, bool cleanupOnExit, bool isBeingTraced)

--- a/src/sdb_process.cpp
+++ b/src/sdb_process.cpp
@@ -113,7 +113,7 @@ ProcessUPtr Process::launch(std::filesystem::path path)
   }
 
   errorPipe.closeWrite();
-  
+
   // Won't this block here?
   auto data = errorPipe.read();
   errorPipe.closeRead();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,12 @@
 add_executable(sdb.u.t
-    sdb_unit.t.cpp
+    sdb_process.t.cpp
 )
 
 include(FetchContent)
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 FetchContent_MakeAvailable(googletest)
 
@@ -13,6 +14,7 @@ target_link_libraries(sdb.u.t
     PRIVATE
     sdb::libsdb
     GTest::gtest_main
+    gmock
 )
 
 include(GoogleTest)

--- a/test/sdb_process.t.cpp
+++ b/test/sdb_process.t.cpp
@@ -1,0 +1,43 @@
+#include <libsdb/sdb_process.h>
+
+#include <filesystem>
+#include <signal.h>
+#include <sstream>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace sdb
+{
+namespace
+{
+using namespace testing;
+
+bool processExists(int pid)
+{
+  const auto rc = kill(pid, 0);
+  return (rc == 0) or (rc == -1 and errno == EPERM);
+}
+
+} // namespace
+
+TEST(ProcessTest, processLaunchedSuccessfully)
+{
+  // Given
+  auto proc = Process::launch("yes");
+
+  // When / Then
+  ASSERT_THAT(proc, NotNull());
+  auto pid = proc->pid();
+  ASSERT_TRUE(processExists(pid))
+    << "Process with pid=" << pid << " not found";
+}
+
+TEST(ProcessTest, launchNonExistentProgram)
+{
+  // Given / When / Then
+  const std::filesystem::path path{ "yess" };
+  EXPECT_THROW(Process::launch(path), ProcessLaunchError);
+}
+
+} // namespace sdb

--- a/test/sdb_process.t.cpp
+++ b/test/sdb_process.t.cpp
@@ -37,6 +37,8 @@ char getProcessStatus(int pid)
   // File names can contains spaces and parenthesis
   // But we can assume the contents of the stat file will
   // be in the format: 1 (systemd) S 0 1 1 0 -1 4194560 1403003 88311080 ...
+  // i.e the proc state is the third field
+  // See https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html
   std::string buf;
   std::getline(ifs, buf);
   const auto idxOfLastParen = buf.rfind(')');

--- a/test/sdb_process.t.cpp
+++ b/test/sdb_process.t.cpp
@@ -1,8 +1,10 @@
 #include <libsdb/sdb_process.h>
 
 #include <filesystem>
+#include <fstream>
 #include <signal.h>
 #include <sstream>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -11,6 +13,7 @@ namespace sdb
 {
 namespace
 {
+
 using namespace testing;
 
 bool processExists(int pid)
@@ -19,12 +22,33 @@ bool processExists(int pid)
   return (rc == 0) or (rc == -1 and errno == EPERM);
 }
 
+char getProcessStatus(int pid)
+{
+  std::stringstream ss;
+  ss << "/proc/" << pid << "/stat";
+
+  std::ifstream ifs(ss.str().c_str());
+
+  if (!ifs.is_open())
+  {
+    return false;
+  }
+
+  // File names can contains spaces and parenthesis
+  // But we can assume the contents of the stat file will
+  // be in the format: 1 (systemd) S 0 1 1 0 -1 4194560 1403003 88311080 ...
+  std::string buf;
+  std::getline(ifs, buf);
+  const auto idxOfLastParen = buf.rfind(')');
+  const auto idxOfProcStatus = idxOfLastParen + 2;
+  return buf[idxOfProcStatus];
+}
 } // namespace
 
 TEST(ProcessTest, processLaunchedSuccessfully)
 {
   // Given
-  auto proc = Process::launch("yes");
+  auto proc = Process::launch("ls");
 
   // When / Then
   ASSERT_THAT(proc, NotNull());
@@ -36,8 +60,26 @@ TEST(ProcessTest, processLaunchedSuccessfully)
 TEST(ProcessTest, launchNonExistentProgram)
 {
   // Given / When / Then
-  const std::filesystem::path path{ "yess" };
-  EXPECT_THROW(Process::launch(path), ProcessLaunchError);
+  const std::filesystem::path procname{ "yess" };
+  EXPECT_THROW(Process::launch(procname), ProcessLaunchError);
+}
+
+TEST(ProcessTest, attachToProcess)
+{
+  // Given
+  const std::filesystem::path procname{ "ls" };
+  const auto proc = Process::launch(procname, /*traceProc*/ false);
+  ASSERT_THAT(proc, NotNull());
+
+  // When
+  const auto attachedProc = Process::attach(proc->pid());
+
+  // Then
+  ASSERT_EQ(proc->pid(), attachedProc->pid());
+  auto processInTracingStoppedStatus
+    = [](int pid) { return getProcessStatus(pid) == 't'; };
+
+  ASSERT_TRUE(processInTracingStoppedStatus(attachedProc->pid()));
 }
 
 } // namespace sdb

--- a/test/sdb_unit.t.cpp
+++ b/test/sdb_unit.t.cpp
@@ -1,6 +1,0 @@
-#include <gtest/gtest.h>
-
-
-TEST(HelloTest, BasicAssertions) {
-  EXPECT_EQ(7*6, 42);
-}


### PR DESCRIPTION
#### Context
* Errors thrown in the inferior are currently not visible to the parent process.

#### Changes
* Introduce a new abstraction over Unix pipes for IPC
* Communicate inferior proc error to parent proc via pipe
* More unit tests

#### Test Plan
* Unit tests