### PR TITLE
Test resuming a process

### DIFF
--- a/include/libsdb/sdb_process.h
+++ b/include/libsdb/sdb_process.h
@@ -41,19 +41,18 @@ private:
   Process(pid_t pid, bool cleanupOnExit, bool isBeingTraced);
 
 private:
-  const pid_t d_pid;
-
+  pid_t d_pid;
   ProcessState d_state;
-  const bool d_cleanupOnExit;
-  const bool d_isBeingTraced;
+  bool d_cleanupOnExit;
+  bool d_isBeingTraced;
 
 public:
   ~Process();
   static ProcessUPtr attach(pid_t pid);
   static ProcessUPtr launch(std::filesystem::path path, bool traceProc = true);
 
-  Process(Process&&) = default;
-  Process& operator=(Process&&) = default;
+  Process(Process&&);
+  Process& operator=(Process&&);
 
   /* Resume the debugee process */
   void resume();

--- a/include/libsdb/sdb_process_state.h
+++ b/include/libsdb/sdb_process_state.h
@@ -15,6 +15,8 @@ enum struct ProcessState
   e_TERMINATED
 };
 
+std::ostream& operator<<(std::ostream& os, ProcessState state);
+
 } // sdb
 
 #endif

--- a/src/sdb_pipe.cpp
+++ b/src/sdb_pipe.cpp
@@ -9,7 +9,6 @@
 
 namespace sdb
 {
-
 namespace
 {
 static const int EMPTY_PIPE_FD = -1;
@@ -17,7 +16,7 @@ static const int EMPTY_PIPE_FD = -1;
 
 Pipe::Pipe(bool closeOnExec)
 {
-  if (auto rc = pipe2(d_fds, 0 | (closeOnExec ? O_CLOEXEC : 0)); rc < 0)
+  if (auto rc = pipe2(d_fds, closeOnExec ? O_CLOEXEC : 0); rc < 0)
   {
     std::stringstream ss;
     ss << "Failed to create pipe, rc=" << rc;

--- a/src/sdb_process.cpp
+++ b/src/sdb_process.cpp
@@ -183,9 +183,10 @@ void Process::resume()
     case ProcessState::e_STOPPED:
       if (int rc = ptrace(PTRACE_CONT, d_pid, nullptr, nullptr); rc < 0)
       {
-        std::cerr << "Unable to continue proc with pid=" << d_pid
-                  << ", rc=" << rc << std::endl;
-        perror("");
+        std::stringstream ss;
+        ss << "Unable to continue proc with pid=" << d_pid << ", rc=" << rc
+           << ". perror=";
+        perror(ss.str().c_str());
         std::exit(-1);
       }
       d_state = ProcessState::e_RUNNING;

--- a/src/sdb_process.cpp
+++ b/src/sdb_process.cpp
@@ -8,7 +8,6 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <utility>
 #include <vector>
 
 namespace sdb

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,3 +19,5 @@ target_link_libraries(sdb.u.t
 
 include(GoogleTest)
 gtest_discover_tests(sdb.u.t)
+
+add_executable(testbin.tsk testbin.m.cpp)

--- a/test/sdb_process.t.cpp
+++ b/test/sdb_process.t.cpp
@@ -1,13 +1,11 @@
 #include <libsdb/sdb_process.h>
 
-#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <signal.h>
 #include <sstream>
 #include <string>
 #include <thread>
-#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -18,7 +16,6 @@ namespace
 {
 
 using namespace testing;
-using namespace std::chrono_literals;
 
 bool processExists(int pid)
 {

--- a/test/testbin.m.cpp
+++ b/test/testbin.m.cpp
@@ -1,0 +1,9 @@
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+int main()
+{
+  std::this_thread::sleep_for(5s);
+}


### PR DESCRIPTION
#### Context
* More tests

#### Changes
* Update the move operators for the `Process` class to ensure the underlying process is not cleaned
  when the object moved out of is destructed.
* Minor bugfixes

#### Test Plan
* CI
